### PR TITLE
fix(docs): stabilize CI documentation builds

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -126,6 +126,7 @@ nb_execution_timeout = 300
 nb_merge_streams = True
 nb_execution_excludepatterns = [
     "**/kpnn-with-sc.ipynb",  # very slow, requires jax, keras
+    "**/multi-pcst-grb.ipynb",  # requires Gurobi and a valid license
     "tutorials/**/*.ipynb",  # one directory below tutorials
     "tutorials/**/**/*.ipynb",  # contributed tutorials nested two levels deep
 ]

--- a/scripts/sync_releases.py
+++ b/scripts/sync_releases.py
@@ -103,7 +103,7 @@ def parse_version_key(tag: str) -> Tuple[int, int, int, int, int]:
 
     # Fallback: extract up to 3 numeric components; treat as stable
     nums = [int(x) for x in re.findall(r"\d+", s)]
-    nums = (nums + [0, 0, 0])[:3]
+    nums = [*nums, 0, 0, 0][:3]
     return (nums[0], nums[1], nums[2], 0, 0)
 
 
@@ -153,7 +153,6 @@ def format_release_date(published_at: Optional[str]) -> str:
 def generate_release_markdown(release: Dict) -> str:
     """Generate Sphinx-compatible markdown for a release."""
     tag_name = release["tag_name"]
-    name = release.get("name") or tag_name
     published_at = format_release_date(release.get("published_at"))
     body = clean_release_body(release.get("body"))
     html_url = release.get("html_url", "")
@@ -224,13 +223,27 @@ def update_releases_index(releases: List[Dict], releases_dir: Path, *, sort_by: 
     """Update the releases index.md file.
 
     The toctree is written in the desired order (newest first). We do not rely on
-    the ``:reversed:`` option.
+    the ``:reversed:`` option. Locally maintained pages that do not correspond to
+    a published GitHub release are preserved in the index.
     """
     sorted_releases = sort_releases(releases, sort_by=sort_by)
+    release_pages = [safe_filename_from_tag(release["tag_name"]) for release in sorted_releases]
+    release_page_set = set(release_pages)
+    local_pages = {
+        path.stem for path in releases_dir.glob("*.md") if path.stem != "index" and path.stem not in release_page_set
+    }
+    local_version_pages = sorted(
+        (page for page in local_pages if _version_re.match(page)),
+        key=parse_version_key,
+        reverse=True,
+    )
+    local_guide_pages = sorted(local_pages - set(local_version_pages))
+    toctree_pages = local_version_pages + local_guide_pages + release_pages
 
     content = """# Release Notes
 
-This section contains detailed release notes for CORNETO versions, documenting new features, improvements, bug fixes, and breaking changes.
+This section contains detailed release notes for CORNETO versions, documenting new features,
+improvements, bug fixes, and breaking changes.
 
 ## Recent Releases
 
@@ -239,10 +252,8 @@ This section contains detailed release notes for CORNETO versions, documenting n
 
 """
 
-    # Add each release to the toctree in already-sorted order
-    for release in sorted_releases:
-        tag_name = release["tag_name"]
-        content += f"{safe_filename_from_tag(tag_name)}\n"
+    for page in toctree_pages:
+        content += f"{page}\n"
 
     content += """```
 
@@ -263,7 +274,9 @@ CORNETO follows [semantic versioning](https://semver.org/) with the following re
 
 ## Contributing to Releases
 
-For information on contributing to CORNETO and the release process, see our [contributing guidelines](https://github.com/saezlab/corneto/blob/main/CONTRIBUTING.md) and [release documentation](https://github.com/saezlab/corneto/blob/main/RELEASE.md).
+For information on contributing to CORNETO and the release process, see our
+[contributing guidelines](https://github.com/saezlab/corneto/blob/main/CONTRIBUTING.md) and
+[release documentation](https://github.com/saezlab/corneto/blob/main/RELEASE.md).
 """
 
     index_file = releases_dir / "index.md"

--- a/tests/test_sync_releases.py
+++ b/tests/test_sync_releases.py
@@ -1,0 +1,15 @@
+"""Tests for the documentation release synchronization script."""
+
+from scripts.sync_releases import update_releases_index
+
+
+def test_release_index_preserves_local_pages(tmp_path):
+    """Keep draft release notes and migration guides in the generated index."""
+    (tmp_path / "v1.0.0-rc.1.md").touch()
+    (tmp_path / "migration-1.0.md").touch()
+    releases = [{"tag_name": "v1.0.0-beta.2"}]
+
+    update_releases_index(releases, tmp_path)
+
+    index = (tmp_path / "index.md").read_text(encoding="utf-8")
+    assert index.index("v1.0.0-rc.1") < index.index("migration-1.0") < index.index("v1.0.0-beta.2")


### PR DESCRIPTION
## Summary
- keep the Gurobi PCST guide indexed without executing it on unlicensed CI runners
- preserve local RC and migration pages when synchronizing published releases
- add a focused regression test for release-index generation

## Validation
- poetry run pytest -q tests/test_sync_releases.py
- poetry run ruff check docs/conf.py scripts/sync_releases.py tests/test_sync_releases.py
- poetry run ruff format --check docs/conf.py scripts/sync_releases.py tests/test_sync_releases.py
- poetry run sphinx-build -W --keep-going -b html docs docs/_build/html