### PR TITLE
docs(release): remove fixed RC soak policy

### DIFF
--- a/docs/releases/v1.0.0-rc.1.md
+++ b/docs/releases/v1.0.0-rc.1.md
@@ -26,9 +26,3 @@ through the CORNETO 1.x line. They are scheduled for removal in CORNETO 2.0.
 
 See the [1.0 migration guide](migration-1.0.md) for canonical mappings and
 intentional removals.
-
-## Release-candidate policy
-
-RC1 must soak for at least seven days. During the soak, only bug fixes,
-documentation corrections, and packaging fixes are accepted. Any public API
-change requires RC2 and restarts the seven-day soak.


### PR DESCRIPTION
## Summary

Remove the mandatory seven-day RC1 soak policy from the release notes. CORNETO can now graduate from RC based on project readiness rather than a fixed waiting period.

## Validation

- documentation-only deletion
- git diff --check